### PR TITLE
Fix #withAnyArguments() typo in example

### DIFF
--- a/fr/chapter2.skriv
+++ b/fr/chapter2.skriv
@@ -2601,7 +2601,7 @@ $this
         ->call('myMethod')
             ->withArguments('first')     ->once()
             ->withArguments('second')    ->once()
-            ->withAnyArgumentsArguments()->exactly(2)
+            ->withAnyArguments()->exactly(2)
 ;
 ]]]
 


### PR DESCRIPTION
fix example 
$this
    ->object(new MySecondClass($mock))
    ->mock($mock)
        ->call('myMethod')
            ->withArguments('first')     ->once()
            ->withArguments('second')    ->once()
            ->withAnyArguments()->exactly(2)

Which had a typo 
