### PR TITLE
Fix version_compare link

### DIFF
--- a/source/en/written_help/annotation-php.inc.rst
+++ b/source/en/written_help/annotation-php.inc.rst
@@ -28,7 +28,7 @@ With this example the test will only be executed if the PHP version is greater o
 By default the tests will pass when a test is skipped. But you can use the :ref:`--fail-if-skipped-methods<cli-opts-fail-if-skipped-methods>` command line option to make the test fail when an extension is not present.
 
 
-Internally, atoum uses PHP's `version_compare<http://php.net/version_compare>`_ function to do the comparison.
+Internally, atoum uses PHP's `version_compare <http://php.net/version_compare>`_ function to do the comparison.
 
 You're not limited to the greater equal operator. You can pass any version_compare operator.
 

--- a/source/fr/aide_ecriture/annotation-php.inc.rst
+++ b/source/fr/aide_ecriture/annotation-php.inc.rst
@@ -27,7 +27,7 @@ Dans cette exemple, le test ne sera exécuté que si la version de PHP est supé
 .. note::
 Par défaut, le test passe lorsqu'il est passé. Mais vous pouvez utiliser :ref:`--fail-if-skipped-methods<cli-opts-fail-if-skipped-methods>` l'option de la ligne de commande afin de faire échoué les tests passés.
 
-En interne, atoum utilise le `comparateur de version de PHP<http://php.net/version_compare>`_ pour effectuer la comparaison.
+En interne, atoum utilise le `comparateur de version de PHP <http://php.net/version_compare>`_ pour effectuer la comparaison.
 
 Vous n'êtes pas limité à l'opérateur égale ou supérieur. Vous pouvez passé tout les opérateurs de version_compare.
 


### PR DESCRIPTION
In my previous PR, a space were missing in the version_compare link :

So the build documentation where displayed like this :

```
 utilise le `comparateur de version de PHP<http://php.net/version_compare>`_
```

Adding the space fixes that.