### PR TITLE
Use Composer as default installation method (and some minor rewording)

### DIFF
--- a/source/en/installation.rst
+++ b/source/en/installation.rst
@@ -8,10 +8,25 @@ If you want to use atoum, simply download the latest version.
 
 You can install atom in several ways:
 
+* using `composer`_;
 * download the `PHAR archive`_ ;
-* use `composer`_;
 * clone the `Github`_ repository;
 * see also the :ref:`integration with your frameworks <utilisation-avec-frameworks>`.
+
+.. _installation-par-composer:
+
+Composer
+========
+
+`Composer <http://getcomposer.org>`_ is a dependency management tool in PHP.
+
+Be sure you have a working composer installation (`official documentation<https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx>`_)
+
+Add ``atoum/atoum`` as a dev dependency :
+
+.. code-block:: json
+
+   composer require --dev atoum/atoum
 
 
 .. _archive-phar:
@@ -109,37 +124,6 @@ The version is then removed.
 .. note::
 	Deleting a version requires the modification of the PHAR archive. the default PHP configuration doesn't allow this. 
 	So it is mandatory to use the directive ``-d phar.readonly=0``.
-
-
-.. _installation-par-composer:
-
-Composer
-========
-
-`Composer <http://getcomposer.org>`_ is a dependency management tool in PHP.
-
-Start by installing composer:
-
-.. code-block:: shell
-
-   $ curl -s https://getcomposer.org/installer | php
-
-Then create a file ``composer.json`` containing the following JSON (JavaScript Object Notation):
-
-.. code-block:: json
-
-   {
-       "require-dev": {
-           "atoum/atoum": "~2.5"
-       }
-   }
-
-Finally, run the following command:
-
-.. code-block:: shell
-
-   $ php composer.phar install
-
 
 .. _installation-par-github:
 

--- a/source/fr/installation.rst
+++ b/source/fr/installation.rst
@@ -8,10 +8,26 @@ Si vous souhaitez utiliser atoum, il vous suffit de télécharger la dernière v
 
 Vous pouvez installer atoum de plusieurs manières :
 
+* via `composer`_ ;
 * en téléchargeant l'`archive PHAR`_ ;
-* à l'aide de `composer`_ ;
 * en clonant le dépôt `Github`_ ;
 * voir aussi :ref:`l'integration d'atoum dans votre framework <utilisation-avec-frameworks>`.
+
+
+.. _installation-par-composer:
+
+Composer
+========
+
+`Composer <http://getcomposer.org>`_ est un outil de gestion de dépendance en PHP.
+
+Assurez vous de disposer d'une installation fonctionnelle de Composer (`documentation officielle (EN)<https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx>`_)
+
+Ajoutez ``atoum/atoum`` comme dépendance de développement :
+
+.. code-block:: shell
+
+   composer require --dev atoum/atoum
 
 
 .. _archive-phar:
@@ -109,36 +125,6 @@ La version est alors supprimée.
 .. note::
 	La suppression d'une version nécessite la modification de l'archive PHAR. par défaut la configuration de PHP ne l'autorise pas. 
 	Voilà pourquoi il faut utiliser la directive ``-d phar.readonly=0``.
-
-
-.. _installation-par-composer:
-
-Composer
-========
-
-`Composer <http://getcomposer.org>`_ est un outil de gestion de dépendance en PHP.
-
-Commencez par installer composer :
-
-.. code-block:: shell
-
-   $ curl -s https://getcomposer.org/installer | php
-
-Créez ensuite un fichier ``composer.json`` contenant le JSON (JavaScript Object Notation) suivant :
-
-.. code-block:: json
-
-   {
-       "require-dev": {
-           "atoum/atoum": "~2.5"
-       }
-   }
-
-Enfin, exécutez la commande suivante :
-
-.. code-block:: shell
-
-   $ php composer.phar install
 
 
 .. _installation-par-github:


### PR DESCRIPTION
I think Composer is the most used installation method today. So this PR put Composer as first method explained for installation
Some minor rewordings in Composer installation method to avoid to reexplain how Composer work
