### PR TITLE
Fix french typos in mocking systems documentation

### DIFF
--- a/source/fr/mocking_systems.rst
+++ b/source/fr/mocking_systems.rst
@@ -416,10 +416,10 @@ atoum permet de très facilement simuler le comportement des fonctions natives d
 
 .. _mock-constant:
 
-Le bouchonage des contantes
+Le bouchonnage des constantes
 ***************************
 
-Les contantes PHP sont déclarée par ``defined``, mais avec atoum vous pouvez bouchonner celles-ci de cette manière:
+Les constantes PHP sont déclarées par ``defined``, mais avec atoum vous pouvez bouchonner celles-ci de cette manière:
 
 .. code-block:: php
 


### PR DESCRIPTION
Bonjour,

J'ai corrigé quelques erreurs que j'ai repérées dans la documentation sur les mock.
Je n'ai pas compris dans ce qui est indiqué dans le README.md s'il faut faire faire autre chose que juste mettre à jour le .rst.