### PR TITLE
fix hasCode message in fr exception documentation

### DIFF
--- a/source/fr/asserters/exception.inc.rst
+++ b/source/fr/asserters/exception.inc.rst
@@ -46,7 +46,7 @@ Nous pouvons même facilement récupérer la dernière exception via ``$this->ex
 hasCode
 =======
 
-``hasMessage`` vérifie le code de l'exception.
+``hasCode`` vérifie le code de l'exception.
 
 .. code-block:: php
 


### PR DESCRIPTION
As we can see here: http://docs.atoum.org/fr/latest/assertions.html#hascode there is a typo.